### PR TITLE
Add script to deploy to PaaS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@
 
 # Vendored Frontend components
 /components
+
+# PaaS authentication file
+Staticfile.auth

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,0 +1,6 @@
+---
+applications:
+- name: gaap-product-pages
+  memory: 64M
+  path: ./build
+  buildpack: staticfile_buildpack

--- a/script/deploy
+++ b/script/deploy
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -e
+
+error() {
+  echo " ! $1"
+}
+
+# Check that we have a Staticfile.auth we can use
+echo "Checking Staticfile.auth..."
+if [[ ! -f Staticfile.auth ]]; then
+  error "You are attempting to deploy to an environment that requires a Staticfile.auth, but do not have one locally."
+  error "Please add a Staticfile.auth file to this directory and try again."
+  error
+  error "For information on generating a Staticfile.auth, see"
+  error "http://docs.cloudfoundry.org/buildpacks/staticfile/index.html#basic-auth"
+  exit 1
+fi
+echo "OK!"
+
+bundle exec middleman build
+cp Staticfile.auth build
+cf target -o govuk-service-manual -s product-pages
+cf push


### PR DESCRIPTION
We want to be able to share this work with others using PaaS, so this
adds a deployment script (borrowed from `tech-docs-template`) for doing
so.

See also: https://gaap-product-pages.cloudapps.digital/