### PR TITLE
Add support for "reverse" grid order

### DIFF
--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -16,7 +16,11 @@ title: Index Page Example
 
   <div class="hero hero--breaded">
     <div class="hero__content">
-      <div class="grid-row">
+      <div class="grid-row grid-row--rtl">
+        <div class="column-one-third">
+          <img src="//placehold.it/646x492/005ea5/ffffff?text=A+supporting+image" class="hero__image">
+        </div>
+
         <div class="column-two-thirds">
           <h1 class="hero__title">Duis aute irure dolor in reprehenderit</h1>
           <p class="hero__description">
@@ -29,9 +33,6 @@ title: Index Page Example
             or <a href="#">do another thing</a> because reasons
           </span>
           <p>Pellentesque commodo arcu in sollicitudin lacinia. Vivamus lacus nibh, maximus nec laoreet eget, condimentum vel mi.</p>
-        </div>
-        <div class="column-one-third">
-          <img src="//placehold.it/646x492/005ea5/ffffff?text=A+supporting+image" class="hero__image">
         </div>
       </div>
     </div>

--- a/source/stylesheets/util/_grid.scss
+++ b/source/stylesheets/util/_grid.scss
@@ -1,0 +1,10 @@
+.grid-row--rtl {
+  .column-quarter,
+  .column-half,
+  .column-three-quarters,
+  .column-one-third,
+  .column-third,
+  .column-two-thirds {
+    float: right;
+  }
+}


### PR DESCRIPTION
This adds a new modifier to `grid-row`, `grid-row--rtl`, which causes
the grid to be layed out from right to left on everything other than a
mobile view. On mobile, the content will stack in the order it's defined
in HTML.

This allows the positioning of an image in the hero unit to be shifted
depending on what it is – if it's an unimportant illustration then it
can appear at the bottom of the hero, but if it's something like a logo it can
appear at the top.