### PR TITLE
Fix IE8

### DIFF
--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -31,7 +31,7 @@ title: Index Page Example
           <p>Pellentesque commodo arcu in sollicitudin lacinia. Vivamus lacus nibh, maximus nec laoreet eget, condimentum vel mi.</p>
         </div>
         <div class="column-one-third">
-          <img src="https://placehold.it/646x492/005ea5/ffffff?text=A+supporting+image" class="hero__image">
+          <img src="//placehold.it/646x492/005ea5/ffffff?text=A+supporting+image" class="hero__image">
         </div>
       </div>
     </div>
@@ -87,7 +87,7 @@ title: Index Page Example
     </div>
     <div class="column-half">
       <section class="content-section">
-        <img src="https://placehold.it/1000x1000" class="content-section__image">
+        <img src="//placehold.it/1000x1000" class="content-section__image">
       </section>
     </div>
   </div>

--- a/source/javascripts/ie.js
+++ b/source/javascripts/ie.js
@@ -1,0 +1,2 @@
+//= require govuk_template/source/assets/javascripts/vendor/html5shiv-printshiv.js
+//= require govuk_template/source/assets/javascripts/vendor/json2

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -15,6 +15,7 @@
     <!--[if gte IE 9]><!--><%= stylesheet_link_tag :fonts, media: :all %><!--<![endif]-->
 
     <%= javascript_include_tag :application %>
+    <!--[if lt IE 9]><%= javascript_include_tag "ie.js" %><![endif]-->
   </head>
 
   <body>

--- a/source/stylesheets/modules/_breadcrumbs.scss
+++ b/source/stylesheets/modules/_breadcrumbs.scss
@@ -53,7 +53,8 @@
   }
 
   &--inverse {
-    border-bottom: 1px rgba($white, 0.25) solid;
+    border-bottom: 1px $white solid;
+    border-bottom-color: rgba($white, 0.25);
 
     .breadcrumbs__item {
       &--active,


### PR DESCRIPTION
- Include the HTML5 shim so that HTML5 elements can be styled
- Fall back to a solid white bottom border for inverted breadcrumbs
- Load placeholder images over the same protocol as the page they’re on