### PR TITLE
Fix images nested inside govuk_template

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -54,6 +54,10 @@ class ImportedAssetPathProcessor
   def call(sprockets_asset)
     filename = File.basename(sprockets_asset.logical_path)
     directory = case sprockets_asset.logical_path
+                # I fought the asset pipeline and the asset pipeline won:
+                # This first `when` statement handles an edge case where images are nested inside
+                # a stylesheets directory, as is the case in govuk_template.
+                when /stylesheets\/images\// then ([app.config[:images_dir]] * 2).join('/')
                 when /images\// then app.config[:images_dir]
                 when /fonts\// then app.config[:fonts_dir]
                 when /stylesheets\// then app.config[:css_dir]
@@ -71,4 +75,3 @@ activate :sprockets do |config|
 end
 
 sprockets.append_path File.join(root, "components")
-

--- a/source/stylesheets/manifest.css.scss
+++ b/source/stylesheets/manifest.css.scss
@@ -7,3 +7,12 @@
 
 //= link govuk_template/source/assets/stylesheets/fonts.css
 //= link govuk_template/source/assets/stylesheets/fonts-ie8.css
+
+//= link govuk_template/source/assets/stylesheets/images/close.png
+//= link govuk_template/source/assets/stylesheets/images/gov.uk_logotype_crown-1x.png
+//= link govuk_template/source/assets/stylesheets/images/gov.uk_logotype_crown.png
+//= link govuk_template/source/assets/stylesheets/images/govuk-crest-2x.png
+//= link govuk_template/source/assets/stylesheets/images/govuk-crest-ie.png
+//= link govuk_template/source/assets/stylesheets/images/govuk-crest.png
+//= link govuk_template/source/assets/stylesheets/images/open-government-licence.png
+//= link govuk_template/source/assets/stylesheets/images/open-government-licence_2x.png


### PR DESCRIPTION
This adds a special case to the ImportedAssetPathProcessor class to deal
with images which are inside the stylesheets directory within
govuk_template.