### PR TITLE
Improve sub navigation example

### DIFF
--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -46,7 +46,7 @@
             <%
               {
                 'About' => '/',
-                'Supplementary Page' => '/supplementary.html',
+                'Supplementary Pages' => '/supplementary.html',
                 'Support' => '/support.html'
               }.each do |title, url|
             %>

--- a/source/stylesheets/modules/_sub-navigation.scss
+++ b/source/stylesheets/modules/_sub-navigation.scss
@@ -15,13 +15,10 @@
  * <nav class="sub-navigation">
  *   <ol itemscope itemtype="http://schema.org/ItemList">
  *     <li class="sub-navigation__item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
- *       <a href="#heading-1" itemprop="item"><span itemprop="name">Heading 1</span></a>
+ *       <a href="page-one.html" itemprop="item"><span itemprop="name">Another page one</span></a>
  *     </li>
  *     <li class="sub-navigation__item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
- *       <a href="#heading-2" itemprop="item"><span itemprop="name">Heading 2</span></a>
- *     </li>
- *     <li class="sub-navigation__item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
- *       <a href="#heading-3" itemprop="item"><span itemprop="name">Heading 3</span></a>
+ *       <a href="page-two.html" itemprop="item"><span itemprop="name">Another page two</span></a>
  *     </li>
  *   </ol>
  * </nav>
@@ -51,6 +48,14 @@
     a:hover,
     a:active {
       text-decoration: underline;
+    }
+  }
+
+  &__item--active {
+    @include bold-16;
+    
+    a:link, a:visited {
+      color: $text-colour;
     }
   }
 }

--- a/source/supplementary/page-one.html.erb
+++ b/source/supplementary/page-one.html.erb
@@ -10,8 +10,11 @@ title: Supplementary Page Example
     <li class="breadcrumbs__item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
       <a href="/" itemprop="item"><span itemprop="name">Product Page</span></a>
     </li>
+    <li class="breadcrumbs__item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
+      <a href="/supplementary.html" itemprop="item"><span itemprop="name">Supplementary pages</span></a>
+    </li>
     <li class="breadcrumbs__item breadcrumbs__item--active" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-      <a href="#main" itemprop="item"><span itemprop="name">Supplementary pages</span></a>
+      <a href="#main" itemprop="item"><span itemprop="name">Another page one</span></a>
     </li>
   </ol>
 </nav>
@@ -21,26 +24,20 @@ title: Supplementary Page Example
     <div class="column-one-third">
       <nav class="sub-navigation">
         <ol itemscope itemtype="http://schema.org/ItemList">
-          <li class="sub-navigation__item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-            <a href="supplementary/page-one.html" itemprop="item"><span itemprop="name">Another page one</span></a>
+          <li class="sub-navigation__item sub-navigation__item--active" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
+            <a href="#main" itemprop="item"><span itemprop="name">Another page one</span></a>
           </li>
           <li class="sub-navigation__item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-            <a href="supplementary/page-two.html" itemprop="item"><span itemprop="name">Another page two</span></a>
+            <a href="page-two.html" itemprop="item"><span itemprop="name">Another page two</span></a>
           </li>
         </ol>
       </nav>
     </div>
 
     <div class="column-two-thirds">
-      <h1 id="heading-1">Supplementary pages</h1>
+      <h1 id="heading-1">Another page one</h1>
       <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
       <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
-      <h2 id="heading-2">Heading 2</h2>
-      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
-      <h3 id="heading-3">Heading 3</h3>
-      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
     </div>
   </div>
 </div>

--- a/source/supplementary/page-two.html.erb
+++ b/source/supplementary/page-two.html.erb
@@ -10,8 +10,11 @@ title: Supplementary Page Example
     <li class="breadcrumbs__item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
       <a href="/" itemprop="item"><span itemprop="name">Product Page</span></a>
     </li>
+    <li class="breadcrumbs__item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
+      <a href="/supplementary.html" itemprop="item"><span itemprop="name">Supplementary pages</span></a>
+    </li>
     <li class="breadcrumbs__item breadcrumbs__item--active" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-      <a href="#main" itemprop="item"><span itemprop="name">Supplementary pages</span></a>
+      <a href="#main" itemprop="item"><span itemprop="name">Another page two</span></a>
     </li>
   </ol>
 </nav>
@@ -22,24 +25,20 @@ title: Supplementary Page Example
       <nav class="sub-navigation">
         <ol itemscope itemtype="http://schema.org/ItemList">
           <li class="sub-navigation__item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-            <a href="supplementary/page-one.html" itemprop="item"><span itemprop="name">Another page one</span></a>
+            <a href="page-one.html" itemprop="item"><span itemprop="name">Another page one</span></a>
           </li>
-          <li class="sub-navigation__item" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-            <a href="supplementary/page-two.html" itemprop="item"><span itemprop="name">Another page two</span></a>
+          <li class="sub-navigation__item sub-navigation__item--active" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
+            <a href="#main" itemprop="item"><span itemprop="name">Another page two</span></a>
           </li>
         </ol>
       </nav>
     </div>
 
     <div class="column-two-thirds">
-      <h1 id="heading-1">Supplementary pages</h1>
-      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
-      <h2 id="heading-2">Heading 2</h2>
+      <h1 id="heading-1">Another page two</h1>
       <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
 
-      <h3 id="heading-3">Heading 3</h3>
+      <h3 id="heading-3">Sub Heading</h3>
       <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
     </div>
   </div>


### PR DESCRIPTION
The intention for the sub navigation is that it’s for sub level pages, not for jump links within content. This fixes the example to better illustrate this, and adds support for ‘active’ sub navigation items.

Fixes #16 