### PR TITLE
Improve hero grid

### DIFF
--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -16,23 +16,24 @@ title: Index Page Example
 
   <div class="hero hero--breaded">
     <div class="hero__content">
-      <div class="grid-row">
-        <div class="column-two-thirds">
-          <h1 class="hero__title">Duis aute irure dolor in reprehenderit</h1>
-          <p class="hero__description">
-            Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-          </p>
-          <a href="#" role="button" class="hero-button">
-            Do this thing
-          </a>
-          <span class="hero-alternative-action">
-            or <a href="#">do another thing</a> because reasons
-          </span>
-          <p>Pellentesque commodo arcu in sollicitudin lacinia. Vivamus lacus nibh, maximus nec laoreet eget, condimentum vel mi.</p>
+      <div class="hero__body">
+        <h1 class="hero__title">Duis aute irure dolor in reprehenderit</h1>
+        <div class="hero__inline-image">
+          <img src="//placehold.it/646x492/005ea5/ffffff?text=A+supporting+image" alt="" role="presentation">
         </div>
-        <div class="column-one-third">
-          <img src="//placehold.it/646x492/005ea5/ffffff?text=A+supporting+image" class="hero__image">
-        </div>
+        <p class="hero__description">
+          Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+        </p>
+        <a href="#" role="button" class="hero-button">
+          Do this thing
+        </a>
+        <span class="hero-alternative-action">
+          or <a href="#">do another thing</a> because reasons
+        </span>
+        <p>Pellentesque commodo arcu in sollicitudin lacinia. Vivamus lacus nibh, maximus nec laoreet eget, condimentum vel mi.</p>
+      </div>
+      <div class="hero__aside-image">
+        <img src="//placehold.it/646x492/005ea5/ffffff?text=A+supporting+image" alt="" role="presentation">
       </div>
     </div>
   </div>

--- a/source/stylesheets/modules/_hero.scss
+++ b/source/stylesheets/modules/_hero.scss
@@ -4,16 +4,20 @@
  * Notes:
  * - If using together with a breadcrumb in a masthead, add the --breaded
  *   modifier to reduce top padding.
+ * - There are two images included – one is shown on mobile (hero__inline-image),
+ *   and the other on tablet and above. Both are optional.
  *
  * Example Usage:
  *
- * <div class="hero hero--breaded">
- *  <div class="hero__content">
- *    <div class="grid-row">
- *      <div class="column-two-thirds">
- *        <h1 class="hero__title">Verify that you've paid to send notifications to a register on a platform.</h1>
+ *  <div class="hero hero--breaded">
+ *    <div class="hero__content">
+ *      <div class="hero__body">
+ *        <h1 class="hero__title">Duis aute irure dolor in reprehenderit</h1>
+ *        <div class="hero__inline-image">
+ *          <img src="//placehold.it/646x492/005ea5/ffffff?text=A+supporting+image" alt="" role="presentation">
+ *        </div>
  *        <p class="hero__description">
- *          Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+ *          Lorem ipsum dolor sit amet, consectetur adipisicing elit
  *        </p>
  *        <a href="#" role="button" class="hero-button">
  *          Do this thing
@@ -21,14 +25,29 @@
  *        <span class="hero-alternative-action">
  *          or <a href="#">do another thing</a> because reasons
  *        </span>
+ *        <p>Pellentesque commodo arcu in sollicitudin lacinia. Vivamus lacus nibh, maximus nec laoreet eget, condimentum vel mi.</p>
+ *      </div>
+ *      <div class="hero__aside-image">
+ *        <img src="//placehold.it/646x492/005ea5/ffffff?text=A+supporting+image" alt="" role="presentation">
  *      </div>
  *    </div>
  *  </div>
- * </div>
  */
 
 .hero {
+  @extend %site-width-container;
+  margin-top: 0;
+  margin-bottom: 0;
   color: $white;
+  padding: $gutter-half 0;
+
+  @include media(tablet) {
+    padding: $gutter 0;
+  }
+
+  &--breaded {
+    padding-top: 0;
+  }
 
   a:link,
   a:visited {
@@ -41,18 +60,6 @@
     color: $light-blue-25;
   }
 
-  &__content {
-    $border-top-width: 10px;
-
-    @extend %site-width-container;
-
-    padding: ($gutter-half + $border-top-width) 0 $gutter-half;
-
-    @include media(tablet) {
-      padding: ($gutter + $border-top-width) 0 $gutter;
-    }
-  }
-
   &__title {
     @include bold-48;
   }
@@ -61,22 +68,62 @@
     @include core-24;
   }
 
-  &__title, &__description {
+  &__title,
+  &__description {
     margin-bottom: $gutter-half;
-    
+
     @include media(tablet) {
       margin-bottom: $gutter;
     }
   }
 
-  &__image {
-    max-width: 100%;
-    margin-top: $gutter-half;
+
+  &__inline-image {
+    text-align: center;
+
+    @include media(tablet) {
+      display: none;
+      visibility: hidden;
+    }
+
+    img {
+      width: 100%;
+      max-width: 320px;
+    }
   }
 
-  &--breaded {
-    .hero__content {
-      padding-top: 0;
+
+  &__aside-image {
+    display: none;
+    visibility: hidden;
+
+    @include media(tablet) {
+      display: block;
+      visibility: visible;
+    }
+
+    img {
+      max-width: 100%;
+      margin-top: $gutter-half;
+    }
+  }
+
+  &__content {
+    @extend %grid-row;
+  }
+
+  &__body,
+  &__aside-image {
+    @include grid-column(1 / 2);
+  }
+
+  @include media(desktop) {
+    &__body {
+      @include grid-column(2 / 3);
+    }
+
+    &__aside-image {
+      @include grid-column(1 / 3);
     }
   }
 }


### PR DESCRIPTION
This tweaks the hero grid system to have slightly different behaviour.
On desktop and above, the body content is 2/3 wide and the image 1/3. On
tablet, it's 1/2 each. On mobile, it stacks as usual.

In addition to that, this changes the behaviour of images; there's now
an "inline image" which is shown on mobile, and an "aside image" which
is shown on other viewports.

Fixes #15.