### PR TITLE
Improve focus state of links in masthead

### DIFF
--- a/source/stylesheets/modules/_breadcrumbs.scss
+++ b/source/stylesheets/modules/_breadcrumbs.scss
@@ -34,7 +34,7 @@
 
   padding: $gutter-one-third 0;
   list-style: none;
-  
+
   @include media(tablet) {
     margin-bottom: $gutter;
   }
@@ -96,6 +96,10 @@
       a:active,
       a:visited {
         color: $white;
+      }
+
+      a:focus {
+        color: $black;
       }
     }
   }

--- a/source/stylesheets/modules/_hero.scss
+++ b/source/stylesheets/modules/_hero.scss
@@ -60,6 +60,10 @@
     color: $light-blue-25;
   }
 
+  a:focus {
+    color: $black;
+  }
+
   &__title {
     @include bold-48;
   }


### PR DESCRIPTION
At the moment these are white on orange, which is not particularly
legible. This changes them to be black on orange, which is.