### PR TITLE
Fix layout and role of the <main> element

### DIFF
--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -60,7 +60,7 @@
       </div>
     </header>
 
-    <main id="main">
+    <main role="main" id="main">
       <%= yield %>
     </main>
 

--- a/source/stylesheets/_core.scss
+++ b/source/stylesheets/_core.scss
@@ -53,6 +53,7 @@ html, body, div, p, h1, h2, h3, h4, h5, h6, article, aside, footer, header, hgro
 }
 
 #main {
+  display: block;
   margin-bottom: $gutter * 3;
 }
 


### PR DESCRIPTION
Internet Explorer < 11 does not style `<main>` elements as blocks, so we need to specify that in order for margin-bottom to have any effect in those browser.

Additionally, for older browsers using assistive technologies the main element does not get the correct ARIA role, so we’ll explicitly give it the main role to work around this.