### PR TITLE
Remove tabindex from the main element

### DIFF
--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -60,7 +60,7 @@
       </div>
     </header>
 
-    <main role="main" id="main" tabindex="-1">
+    <main role="main" id="main">
       <%= yield %>
     </main>
 


### PR DESCRIPTION
The `tabindex` attribute was added to the main element in f05ca1fb71f16728bb7a52462b11a850420f36f0  to ensure that the skip links works across all browsers. However, it creates issues in that the focus style is now applied to the main element whenever it is clicked, which is not ideal. This is compounded by the fact that the outline only appears on the top and bottom edges of the main element (the left and right being off screen) which makes it look less like a focus indicator and more like a rendering bug.

I had a brief discussion with the accessibility team, during which we explored the behaviour on other parts of GOV.UK and we found that 1) the tab index attribute is not set on skip link destinations elsewhere that we can find and 2) adding the tab index attribute causes the same issues on those pages.

We’re going to remove this for now until we can find a solution that works for all users.