### PR TITLE
Match header to GOV.UK, typography to GOV.UK elements

### DIFF
--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -43,18 +43,18 @@ title: Index Page Example
   <div class="grid-row">
     <div class="column-two-thirds">
       <section class="content-section">
-        <h2 class="content-section__title">A section</h2>
-        <p class="content-section__body">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+        <h2 class="heading-large content-section__first-heading">A section</h2>
+        <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
       </section>
 
       <section class="content-section content-section--with-top-border">
-        <h2 class="content-section__title">A section</h2>
-        <p class="content-section__body">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+        <h2 class="heading-large content-section__first-heading">Another section</h2>
+        <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
       </section>
 
       <section class="content-section content-section--with-top-border">
-        <h2 class="content-section__title">A section</h2>
-        <p class="content-section__body">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+        <h2 class="heading-large content-section__first-heading">A third section</h2>
+        <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
       </section>
     </div>
 
@@ -73,14 +73,17 @@ title: Index Page Example
   <section class="content-section content-section--with-top-border">
     <div class="grid-row">
       <div class="column-two-thirds">
-        <h2 class="content-section__title">A full-width section</h2>
+        <h2 class="heading-large content-section__first-heading">A full-width section</h2>
         <p class="content-section__body">This section is full-width on tablet and above.</p>
+
+        <h3 class="heading-medium content-section__first-heading">A heading</h3>
+        <p class="content-section__body">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit.</p>
       </div>
     </div>
   </section>
 
   <section class="content-section content-section--with-top-border">
-    <h2 class="content-section__title">Lists in two columns</h2>
+    <h2 class="heading-large content-section__first-heading">Lists in two columns</h2>
     <div class="grid-row">
       <div class="column-one-half">
         <p>Here's a list of things:</p>
@@ -117,7 +120,7 @@ title: Index Page Example
   <div class="grid-row">
     <div class="column-half">
       <section class="content-section content-section--with-top-border">
-        <h2 class="content-section__title">A section with an image</h2>
+        <h2 class="heading-large content-section__first-heading">A section with an image</h2>
         <p>On tablet screen sizes and above, this is a left-aligned section with an image to the right.</p>
       </section>
     </div>
@@ -131,7 +134,7 @@ title: Index Page Example
   <div class="grid-row">
     <div class="column-two-thirds">
       <section class="content-section content-section--with-top-border">
-        <h2 class="content-section__title">A section with a video</h2>
+        <h2 class="heading-large content-section__first-heading">A section with a video</h2>
         <div class="responsive-embed responsive-embed--16by9 responsive-embed--bordered">
           <div class="responsive-embed__wrapper">
             <iframe width="560" height="315" src="https://www.youtube.com/embed/Vtu7eKc6QpY" frameborder="0" allowfullscreen=""></iframe>

--- a/source/stylesheets/_core.scss
+++ b/source/stylesheets/_core.scss
@@ -15,6 +15,7 @@
 
 @import "govuk_elements/public/sass/elements/helpers";
 @import "govuk_elements/public/sass/elements/buttons";
+@import "govuk_elements/public/sass/elements/elements-typography";
 @import "govuk_elements/public/sass/elements/forms";
 @import "govuk_elements/public/sass/elements/layout";
 @import "govuk_elements/public/sass/elements/lists";
@@ -47,19 +48,9 @@ html, body {
   @include core-19;
 }
 
-html, body, div, p, h1, h2, h3, h4, h5, h6, article, aside, footer, header, hgroup, nav, section {
-  margin: 0;
-  padding: 0;
-  vertical-align: baseline;
-}
-
 #main {
   display: block;
   margin-bottom: $gutter * 3;
-}
-
-h1, h2, h3, h4, h5, h6, p {
-  margin: $gutter-half 0;
 }
 
 .container {

--- a/source/stylesheets/modules/_breadcrumbs.scss
+++ b/source/stylesheets/modules/_breadcrumbs.scss
@@ -35,10 +35,6 @@
   padding: $gutter-one-third 0;
   list-style: none;
 
-  @include media(tablet) {
-    margin-bottom: $gutter;
-  }
-
   ol {
     margin: 0;
     padding: 0;

--- a/source/stylesheets/modules/_content-section.scss
+++ b/source/stylesheets/modules/_content-section.scss
@@ -15,11 +15,6 @@
 .content-section {
   margin-top: $gutter;
 
-  &__title {
-    @include bold-36;
-    margin-top: 0;
-  }
-
   &__image {
     max-width: 100%;
   }
@@ -27,5 +22,9 @@
   &--with-top-border {
     padding-top: $gutter;
     border-top: 1px $grey-3 solid;
+    
+    .content-section__first-heading {
+      margin-top: 0;
+    }
   }
 }

--- a/source/stylesheets/modules/_govuk-logo.scss
+++ b/source/stylesheets/modules/_govuk-logo.scss
@@ -19,6 +19,7 @@
 
 .govuk-logo {
   font-weight: bold;
+  display: inline-block;
 
   @include screen {
     background-image: image-url('govuk_template/source/assets/stylesheets/images/gov.uk_logotype_crown-1x.png');
@@ -30,6 +31,7 @@
     }
 
     @include media(tablet) {
+      margin-right: 8px;
       background-position: 0 1px;
     }
   }
@@ -37,6 +39,7 @@
 
 .govuk-logo__printable-crown {
   vertical-align: middle;
+  margin-right: 1px;
 
   @include screen {
     visibility: hidden;

--- a/source/stylesheets/modules/_header.scss
+++ b/source/stylesheets/modules/_header.scss
@@ -55,7 +55,7 @@ $active-nav-color: #1d8feb;
   @extend %contain-floats;
   zoom: 1;
 
-  padding: 8px 0;
+  padding: 9px 0 6px;
 
   @include screen {
     border-bottom: 10px solid $mainstream-brand;
@@ -155,7 +155,6 @@ $active-nav-color: #1d8feb;
     display: inherit;
     float: none;
     clear: none;
-    padding-left: 5px;
   }
 
   .phase-banner {

--- a/source/stylesheets/modules/_masthead.scss
+++ b/source/stylesheets/modules/_masthead.scss
@@ -13,9 +13,4 @@
 
 .masthead {
   background-color: $govuk-blue;
-  margin-bottom: $gutter-half;
-
-  @include media(tablet) {
-    margin-bottom: $gutter;
-  }
 }

--- a/source/stylesheets/modules/_related-items.scss
+++ b/source/stylesheets/modules/_related-items.scss
@@ -15,7 +15,7 @@
 
 .related-items {
   border-top: 10px solid $govuk-blue;
-  margin: $gutter 0;
+  margin: ($gutter * 1.5) 0;
 
   &__title {
     @include bold-24;

--- a/source/stylesheets/modules/_sub-navigation.scss
+++ b/source/stylesheets/modules/_sub-navigation.scss
@@ -26,7 +26,7 @@
 
 .sub-navigation {
   @include media(tablet) {
-    margin-top: $gutter-half;
+    margin-top: $gutter * 1.5;
   }
 
   ol,

--- a/source/supplementary.html.erb
+++ b/source/supplementary.html.erb
@@ -32,14 +32,14 @@ title: Supplementary Page Example
     </div>
 
     <div class="column-two-thirds">
-      <h1 id="heading-1">Supplementary pages</h1>
+      <h1 class="heading-large">Supplementary pages</h1>
       <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
       <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
 
-      <h2 id="heading-2">Heading 2</h2>
+      <h2 class="heading-medium">Heading 2</h2>
       <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
 
-      <h3 id="heading-3">Heading 3</h3>
+      <h3 class="heading-medium">Heading 3</h3>
       <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
     </div>
   </div>

--- a/source/supplementary/page-one.html.erb
+++ b/source/supplementary/page-one.html.erb
@@ -35,7 +35,7 @@ title: Supplementary Page Example
     </div>
 
     <div class="column-two-thirds">
-      <h1 id="heading-1">Another page one</h1>
+      <h1 class="heading-large">Another page one</h1>
       <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
       <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
     </div>

--- a/source/supplementary/page-two.html.erb
+++ b/source/supplementary/page-two.html.erb
@@ -35,10 +35,10 @@ title: Supplementary Page Example
     </div>
 
     <div class="column-two-thirds">
-      <h1 id="heading-1">Another page two</h1>
+      <h1 class="heading-large">Another page two</h1>
       <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
 
-      <h3 id="heading-3">Sub Heading</h3>
+      <h2 class="heading-medium">Sub Heading</h2>
       <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
     </div>
   </div>

--- a/source/support.html.erb
+++ b/source/support.html.erb
@@ -20,7 +20,7 @@ title: Support Page Example
   <div class="grid-row">
 
     <div class="column-two-thirds">
-      <h1>Get Support</h1>
+      <h1 class="heading-large">Get support</h1>
       <p>Do you have a problem or question? Please send a detailed description to our support team.</p>
 
       <div class="panel panel-border-wide">


### PR DESCRIPTION
See individual commits for details.

## Homepage

### Before
![screencapture-localhost-4567-1484923686332](https://cloud.githubusercontent.com/assets/121939/22153526/a0382e12-df1f-11e6-9dcf-7fddb51843a8.png)

### After
![screencapture-localhost-4567-1484923725165](https://cloud.githubusercontent.com/assets/121939/22153532/a3e18450-df1f-11e6-9545-16dd3485d5de.png)

## Supplementary Pages
### Before
![screencapture-localhost-4567-supplementary-html-1484923698168](https://cloud.githubusercontent.com/assets/121939/22153542/ad3b238a-df1f-11e6-85ed-2cf3d2d7de0d.png)

### After
![screencapture-localhost-4567-supplementary-html-1484923730692](https://cloud.githubusercontent.com/assets/121939/22153546/b05eb81a-df1f-11e6-8803-5282d6ee941a.png)

## Support Page

### Before
![screencapture-localhost-4567-support-html-1484923709448](https://cloud.githubusercontent.com/assets/121939/22153549/b9d76dc4-df1f-11e6-9a65-c5bff76cb94c.png)

### After
![screencapture-localhost-4567-support-html-1484923734552](https://cloud.githubusercontent.com/assets/121939/22153553/bcd0a860-df1f-11e6-941c-6374f9f81367.png)


Fixes #28 and #29.