### PR TITLE
Fix product page deployments by pinning govuk_elements

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,6 +15,6 @@
   "dependencies": {
     "govuk_template": "git://github.com/alphagov/govuk_template.git#^0.19.2",
     "govuk_frontend_toolkit": "git://github.com/alphagov/govuk_frontend_toolkit#v5.0.2",
-    "govuk_elements": "git://github.com/alphagov/govuk_elements"
+    "govuk_elements": "git://github.com/alphagov/govuk_elements#3.0.2"
   }
 }


### PR DESCRIPTION
Product page deployments are currently broken for PaaS and possibly other teams when deployed from a fresh clone of the repo. See alphagov/paas-product-page#20 for more details.

While #38 is already open to address making the necessary changes to move to a new version of govuk_elements, in the interim I think we should make sure that master is deployable by pinning the version of govuk_elements used.


