### PR TITLE
Pin current latest govuk_template

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
     "napa": "^3.0.0"
   },
   "scripts": {
-    "install": "napa alphagov/govuk_template"
+    "install": "napa"
+  },
+  "napa": {
+    "govuk_template": "alphagov/govuk_template#v0.22.3"
   }
 }


### PR DESCRIPTION
Using the default {username}/{repo} syntax with napa will just install the latest version of a repo's master branch into the local `/node_modules`. Without an explicit version, this means that every time there is a commit to [govuk_template](https://github.com/alphagov/govuk_template), we'll end up with slightly different code.

Pinning a version means we get the same thing every time, and the new syntax in `package.json` lets us keep the folder name the same as it was before.

***
Note: the default napa syntax (`napa alphagov/govuk_template`) was also consistently causing errors for me, although the error message wasn't specific to napa. Found [one similar-looking reported bug](https://github.com/shama/napa/issues/50) but none of the recommendations helped. 
Pinning a version is working without problems.

<details>
<summary>Stack trace</summary>
<br>

Using:

- node v4.8.3 (npm v2.15.11)
- node v6.11.0 (npm v5.3.0)

```
gds3000:product-page-example paulcraig$ npm install

> product-page-example@1.0.0 install /Users/paulcraig/Desktop/gds/product-page-example
> napa alphagov/govuk_template

info cache git://github.com/alphagov/govuk_template into govuk_template
events.js:160
      throw er; // Unhandled 'error' event
      ^

Error: EISDIR: illegal operation on a directory, read
    at Error (native)
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! product-page-example@1.0.0 install: `napa alphagov/govuk_template`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the product-page-example@1.0.0 install script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/paulcraig/.npm/_logs/2017-07-26T15_41_46_794Z-debug.log
```
</details>