### PR TITLE
Remove extraneous leading slash

### DIFF
--- a/source/stylesheets/modules/_hero-button.scss
+++ b/source/stylesheets/modules/_hero-button.scss
@@ -21,7 +21,7 @@ a.hero-button {
   @include bold-24;
   @include box-shadow(0 2px 0 darken($govuk-blue, 10%));
 
-  background-image: file-url('/images/hero-button/arrow.png');
+  background-image: file-url('images/hero-button/arrow.png');
   background-size: 20px;
   background-repeat: no-repeat;
   background-position: 95% 50%;
@@ -33,7 +33,7 @@ a.hero-button {
   text-align: center;
 
   @include device-pixel-ratio(2) {
-    background-image: file-url('/images/hero-button/arrow@2x.png');
+    background-image: file-url('images/hero-button/arrow@2x.png');
   }
 
   @include media(tablet) {


### PR DESCRIPTION
Because another slash is added in by `file-url` and you end up with double slashes. See: https://github.com/aioutecism/sass-file-url/blob/master/file-url.rb

This is causing a 404 when I serve this in python for PaaS.