### PR TITLE
Flipping the aria hidden boolean

### DIFF
--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -53,7 +53,7 @@
         <div data-module="navigation">
           <button type="button" class="header__navigation-toggle js-nav-toggle" aria-controls="navigation" aria-label="Show or hide top level navigation">Menu</button>
 
-          <nav id="navigation" class="header__navigation js-nav" aria-label="Top Level Navigation" aria-hidden="true" data-click-events data-click-category="Header" data-click-action="Navigation link clicked">
+          <nav id="navigation" class="header__navigation js-nav" aria-label="Top Level Navigation" data-click-events data-click-category="Header" data-click-action="Navigation link clicked">
             <ul>
               <%
                 {


### PR DESCRIPTION
so that the navigation is read out by screen readers, if the page
opens on mobile, then navigation.js kicks in and toggles the menu toggle
and changes aria-hidden to true.